### PR TITLE
Include original css js files

### DIFF
--- a/src/main/java/fr/jmini/utils/htmlpublish/helper/internal/Impl.java
+++ b/src/main/java/fr/jmini/utils/htmlpublish/helper/internal/Impl.java
@@ -1,19 +1,5 @@
 package fr.jmini.utils.htmlpublish.helper.internal;
 
-import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog;
-import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.OutputAction;
-import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.Strategy;
-import fr.jmini.utils.htmlpublish.helper.ConfigurationHolder;
-import fr.jmini.utils.htmlpublish.helper.ConfigurationOptions;
-import fr.jmini.utils.htmlpublish.helper.ConfigurationPage;
-import fr.jmini.utils.htmlpublish.helper.ConfigurationPageOptions;
-import fr.jmini.utils.htmlpublish.helper.IndexHandling;
-import fr.jmini.utils.htmlpublish.helper.LinkToIndexHtmlStrategy;
-import fr.jmini.utils.htmlpublish.helper.RewriteStrategy;
-import fr.jmini.utils.pathorder.AbsolutePathComparator;
-import fr.jmini.utils.pathorder.Order;
-import fr.jmini.utils.pathorder.Pages;
-import fr.jmini.utils.pathorder.SortConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +27,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.DocumentType;
@@ -49,7 +36,20 @@ import org.jsoup.select.Elements;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.error.YAMLException;
 
-
+import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog;
+import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.OutputAction;
+import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.Strategy;
+import fr.jmini.utils.htmlpublish.helper.ConfigurationHolder;
+import fr.jmini.utils.htmlpublish.helper.ConfigurationOptions;
+import fr.jmini.utils.htmlpublish.helper.ConfigurationPage;
+import fr.jmini.utils.htmlpublish.helper.ConfigurationPageOptions;
+import fr.jmini.utils.htmlpublish.helper.IndexHandling;
+import fr.jmini.utils.htmlpublish.helper.LinkToIndexHtmlStrategy;
+import fr.jmini.utils.htmlpublish.helper.RewriteStrategy;
+import fr.jmini.utils.pathorder.AbsolutePathComparator;
+import fr.jmini.utils.pathorder.Order;
+import fr.jmini.utils.pathorder.Pages;
+import fr.jmini.utils.pathorder.SortConfig;
 
 public class Impl {
 

--- a/src/main/java/fr/jmini/utils/htmlpublish/helper/internal/PageHolder.java
+++ b/src/main/java/fr/jmini/utils/htmlpublish/helper/internal/PageHolder.java
@@ -1,14 +1,14 @@
 package fr.jmini.utils.htmlpublish.helper.internal;
 
+import fr.jmini.utils.htmlpublish.helper.ConfigurationPageOptions;
+import fr.jmini.utils.htmlpublish.helper.LinkToIndexHtmlStrategy;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.jsoup.nodes.Document;
 
-import fr.jmini.utils.htmlpublish.helper.ConfigurationPageOptions;
-import fr.jmini.utils.htmlpublish.helper.LinkToIndexHtmlStrategy;
+
 
 class PageHolder implements Link {
     private PageMapping pageMapping;
@@ -20,6 +20,8 @@ class PageHolder implements Link {
     private PageHolder previous;
     private PageHolder next;
     private String title;
+    private List<String> cssFileNames;
+    private List<String> jsFileNames;
     private LinkToIndexHtmlStrategy linkToIndexHtmlStrategy;
 
     public PageHolder(PageMapping pageMapping, PageHolder parent, boolean uniqueRoot, Document document, String title, LinkToIndexHtmlStrategy linkToIndexHtmlStrategy) {
@@ -98,6 +100,17 @@ class PageHolder implements Link {
     public boolean isTitleSet() {
         return pageMapping.getTitle() != null || title != null;
     }
+
+    public void setCssFileNames(List<String> cssFileNames) {
+        this.cssFileNames = cssFileNames;
+    }
+
+    public List<String> getCssFileNames() { return cssFileNames; }
+
+    public void setJsFileNames(List<String> jsFileNames) {
+        this.jsFileNames = jsFileNames;
+    }
+    public List<String> getJsFileNames() { return jsFileNames; }
 
     @Override
     public String getHrefValue(Path fromCurrentOutputPath) {

--- a/src/test/java/fr/jmini/utils/htmlpublish/helper/internal/ImplTest.java
+++ b/src/test/java/fr/jmini/utils/htmlpublish/helper/internal/ImplTest.java
@@ -3,22 +3,6 @@ package fr.jmini.utils.htmlpublish.helper.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.junit.jupiter.api.Test;
-
 import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog;
 import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.OutputAction;
 import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.Strategy;
@@ -30,6 +14,19 @@ import fr.jmini.utils.htmlpublish.helper.IndexHandling;
 import fr.jmini.utils.htmlpublish.helper.LinkToIndexHtmlStrategy;
 import fr.jmini.utils.htmlpublish.helper.RewriteStrategy;
 import fr.jmini.utils.htmlpublish.helper.internal.Impl.HrefHolder;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+
 
 class ImplTest {
     private static final Path INPUT_FOLDER = Paths.get("src/test/resources/input");
@@ -410,8 +407,11 @@ class ImplTest {
 
         String content1 = Impl.readFile(page1File);
         assertThat(content1).isNotEmpty()
-                .doesNotContain("href=\"static/css/site.css\"") // include 'site.css'
-                .doesNotContain("src=\"assets/js/site.js\"") // include 'site.js'
+                .doesNotContain("href=\"static/css/site.css\"") // don't include 'site.css'
+                .doesNotContain("src=\"static/js/site.js\"") // don't include 'site.js'
+                .doesNotContain("href=\"static/css/page_c1a4d1f.css\"")
+                .contains("href=\"static/css/file_f65f9d4.css\"")
+                .contains("src=\"static/js/empty_9f7f886.js\"")
                 .contains("<title>Page</title>")
                 .contains("<h1 class=\"page\">Page</h1>")
                 .contains("<a class=\"navbar-item\" href=\"page.html\">Page</a>")

--- a/src/test/java/fr/jmini/utils/htmlpublish/helper/internal/ImplTest.java
+++ b/src/test/java/fr/jmini/utils/htmlpublish/helper/internal/ImplTest.java
@@ -3,6 +3,22 @@ package fr.jmini.utils.htmlpublish.helper.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.Test;
+
 import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog;
 import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.OutputAction;
 import fr.jmini.utils.htmlpublish.helper.ConfigurationCatalog.Strategy;
@@ -14,19 +30,6 @@ import fr.jmini.utils.htmlpublish.helper.IndexHandling;
 import fr.jmini.utils.htmlpublish.helper.LinkToIndexHtmlStrategy;
 import fr.jmini.utils.htmlpublish.helper.RewriteStrategy;
 import fr.jmini.utils.htmlpublish.helper.internal.Impl.HrefHolder;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
-
-
 
 class ImplTest {
     private static final Path INPUT_FOLDER = Paths.get("src/test/resources/input");


### PR DESCRIPTION
* If `includeDefaultCss` is `false`, add all CSS files referenced by the original document to the output document.
* If `includeDefaultJs` is `false`, add all JavaScript files referenced by the original document to the output document.